### PR TITLE
add 'MongoDB' to site title

### DIFF
--- a/config/build_conf.yaml
+++ b/config/build_conf.yaml
@@ -7,7 +7,7 @@ project:
   name: 'ruby-driver'
   tag: 'ruby-driver'
   url: 'https://docs.mongodb.com/ruby-driver'
-  title: 'Ruby Driver Manual'
+  title: 'MongoDB Ruby Driver Manual'
   branched: true
 version:
   release: 'upcoming'


### PR DESCRIPTION
As requested, this updates the config file so the docs site will
display 'MongoDB Ruby Driver Manual' instead of 'Ruby Driver Manual'