### PR TITLE
Update Makefile to publish to DOP-owned AWS buckets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ USER=$(shell whoami)
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 PRODUCTION_URL="https://docs.mongodb.com"
 	
-STAGING_BUCKET=docs-mongodb-org-staging
-PRODUCTION_BUCKET=docs-ruby-driver
+STAGING_BUCKET=docs-mongodb-org-stg
+PRODUCTION_BUCKET=docs-mongodb-org-prd
 
 PROJECT=ruby-driver
 TARGET_DIR=source-${GIT_BRANCH}


### PR DESCRIPTION
Same situation as with PHP Library -- updates to point to DOP-owned AWS buckets rather than the monolithic 10gen-noc bucket. Again, it would be great if y'all can backport to the other versions of the driver docs and then republish.