### PR TITLE
adds redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,7 +1,7 @@
 define: prefix ruby-driver
 define: base https://docs.mongodb.com/${prefix}
 define: mongoid_base https://docs.mongodb.com/mongoid
-define: versions v1.x v2.0 v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 v2.7 v2.8 v2.9 v2.10 v2.11 v2.12 v2.13 v2.14 v2.15 master
+define: versions v1.x v2.0 v2.1 v2.2 v2.3 v2.4 v2.5 v2.6 v2.7 v2.8 v2.9 v2.10 v2.11 v2.12 v2.13 v2.14 v2.15 v2.16 master
 symlink: current -> v2.15
 
 
@@ -78,3 +78,45 @@ raw: /${prefix} -> ${base}/current/
 [v2.2-*]: ${prefix}/${version}/tutorials/5.2.0/mongoid-persistence -> ${mongoid_base}/v5.2/tutorials/mongoid-persistence/
 [v2.2-*]: ${prefix}/${version}/tutorials/5.2.0/mongoid-relations -> ${mongoid_base}/v5.2/tutorials/mongoid-relations/
 [v2.7-*]: ${prefix}/${version}/tutorials/ruby-driver-admin-tasks -> ${base}/${version}/tutorials/ruby-driver-database-tasks/
+# redirects for 2.15
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-aggregation -> ${base}/${version}/reference/aggregation/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-authentication -> ${base}/${version}/reference/authentication/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-bulk-operations -> ${base}/${version}/reference/bulk-operations/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-change-streams -> ${base}/${version}/reference/change-streams/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-collations -> ${base}/${version}/reference/collations/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-collection-tasks -> ${base}/${version}/reference/collection-tasks/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-create-client -> ${base}/${version}/reference/create-client/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-crud-operations -> ${base}/${version}/reference/crud-operations/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-database-tasks -> ${base}/${version}/reference/database-tasks/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-geospatial-search -> ${base}/${version}/reference/geospatial-search/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-gridfs -> ${base}/${version}/reference/gridfs/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-monitoring -> ${base}/${version}/reference/monitoring/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-projections -> ${base}/${version}/reference/projection/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-sessions -> ${base}/${version}/reference/sessions/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-text-search -> ${base}/${version}/reference/text-search/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-transactions -> ${base}/${version}/reference/transactions/
+[v2.15-*]: ${prefix}/${version}/tutorials/user-management -> ${base}/${version}/reference/user-management/
+[v2.15-*]: ${prefix}/${version}/tutorials/query-cache -> ${base}/${version}/reference/query-cache/
+[v2.15-*]: ${prefix}/${version}/quick-start -> ${base}/${version}/tutorials/quick-start/
+# redirects for 2.16
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-aggregation -> ${base}/${version}/reference/aggregation/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-authentication -> ${base}/${version}/reference/authentication/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-bulk-operations -> ${base}/${version}/reference/bulk-operations/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-change-streams -> ${base}/${version}/reference/change-streams/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-collations -> ${base}/${version}/reference/collations/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-collection-tasks -> ${base}/${version}/reference/collection-tasks/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-create-client -> ${base}/${version}/reference/create-client/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-crud-operations -> ${base}/${version}/reference/crud-operations/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-database-tasks -> ${base}/${version}/reference/database-tasks/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-geospatial-search -> ${base}/${version}/reference/geospatial-search/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-gridfs -> ${base}/${version}/reference/gridfs/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-monitoring -> ${base}/${version}/reference/monitoring/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-projections -> ${base}/${version}/reference/projection/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-sessions -> ${base}/${version}/reference/sessions/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-text-search -> ${base}/${version}/reference/text-search/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-transactions -> ${base}/${version}/reference/transactions/
+[v2.16-*]: ${prefix}/${version}/tutorials/user-management -> ${base}/${version}/reference/user-management/
+[v2.16-*]: ${prefix}/${version}/tutorials/query-cache -> ${base}/${version}/reference/query-cache/
+[v2.16-*]: ${prefix}/${version}/quick-start -> ${base}/${version}/tutorials/quick-start/


### PR DESCRIPTION
This adds redirects to avoid broken links that were introduced in https://github.com/mongodb/mongo-ruby-driver/pull/2226 and reported in [DOCSP-18655](https://jira.mongodb.org/browse/DOCSP-18655)