### PR TITLE
DOP-3026: publish manifests to correct bucket/path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PRODUCTION_URL="https://docs.mongodb.com"
 
 STAGING_BUCKET=docs-mongodb-org-prd-staging
 PRODUCTION_BUCKET=docs-mongodb-org-prd
+SEARCH_INDEX_BUCKET=docs-search-indexes-test
 
 PROJECT=ruby-driver
 PREFIX=ruby-driver
@@ -74,9 +75,9 @@ deploy: build/public/${GIT_BRANCH} ## Deploy to the production bucket
 deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
 	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-ruby-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH}  -b ${PRODUCTION_BUCKET} -g -s; \
+		mut-index upload build/public/${GIT_BRANCH} -o docs-ruby-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH}  -b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd -g -s; \
 	else \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-ruby-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH}  -b ${PRODUCTION_BUCKET} -s; \
+		mut-index upload build/public/${GIT_BRANCH} -o docs-ruby-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH}  -b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd -s; \
 	fi
 
 # in case you want to just generate the api-docs


### PR DESCRIPTION
Search is now using the docs-search-indexes-test bucket, not the old bucket(s) we were using previously. This updates the Makefile that y'all use for deploys to put the manifests into the right bucket.

I've manually copied the existing manifests over so that search will work as designed from the main docs search, this will just ensure that updates end up in the right place. You'll probably want to back-port the changes to the earlier editions that are actively maintained.


add this to the top:

SEARCH_INDEX_BUCKET=docs-search-indexes-test

replace the `-b` argument in the `mut-index` invocations with this:

-b ${SEARCH_INDEX_BUCKET} -p search-indexes/prd
