### PR TITLE
DOP-3397: set up docs-ruby to build with Snooty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "mongo-ruby-driver"]
+	path = mongo-ruby-driver
+	url = git@github.com:mongodb/mongo-ruby-driver.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-ruby-driver"]
 	path = mongo-ruby-driver
-	url = git@github.com:mongodb/mongo-ruby-driver.git
+	url = https://github.com/mongodb/mongo-ruby-driver.git
 	branch = master

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ api-docs:
 		--exclude ${SOURCE_FILE_DIR}/spec \
 		--readme ${SOURCE_FILE_DIR}/README.md -o build/public/${GIT_BRANCH}/api/
 
-migrate: 
+migrate: get-assets
 	@echo "Making target source directory -- doing this explicitly instead of via cp"
 	if [ -d ${TARGET_DIR} ]; then rm -rf ${TARGET_DIR} ; fi;
 	mkdir ${TARGET_DIR}

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ api-docs:
 		--exclude ${SOURCE_FILE_DIR}/spec \
 		--readme ${SOURCE_FILE_DIR}/README.md -o build/public/${GIT_BRANCH}/api/
 
-migrate: get-assets
+migrate: 
 	@echo "Making target source directory -- doing this explicitly instead of via cp"
 	if [ -d ${TARGET_DIR} ]; then rm -rf ${TARGET_DIR} ; fi;
 	mkdir ${TARGET_DIR}

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,0 +1,4 @@
+name = "ruby-driver"
+title = "Ruby MongoDB Driver"
+
+intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv"]

--- a/worker.sh
+++ b/worker.sh
@@ -1,0 +1,1 @@
+"build-and-stage-next-gen"


### PR DESCRIPTION
**Important note**: we have done *nothing* to handle the generation of the API docs using yarn. We will need to coordinate with the Ruby driver engineers to sort out a solution to the generation of those API docs since it doesn't really make sense for it to go through the Autobuilder / be part of this repo anymore.

Once this PR is merged, the `master` branch of docs-ruby will be deployable using the /deploy command and build with snooty.