### PR TITLE
Update Makefile to publish to correct location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,20 @@ USER=`whoami`
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 PRODUCTION_URL="https://docs.mongodb.com"
 	
-STAGING_BUCKET=docs-mongodb-org-stg
-PRODUCTION_BUCKET=docs-mongodb-org-prd
 
 PROJECT=ruby-driver
+
+STAGING_BUCKET=docs-mongodb-org-prd-staging
+PRODUCTION_BUCKET=docs-mongodb-org-prd
+
+PREFIX=ruby-driver
+DOTCOM_STAGING_URL="https://mongodbcom-cdn.website.staging.corp.mongodb.com"
+DOTCOM_STAGING_BUCKET=docs-mongodb-org-dotcomstg
+DOTCOM_PRODUCTION_URL="https://mongodb.com"
+DOTCOM_PRODUCTION_BUCKET=docs-mongodb-org-dotcomprd
+DOTCOM_PREFIX=docs-qa/ruby-driver
+DOTCOM_STGPREFIX=docs-qa/ruby-driver
+
 
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.


### PR DESCRIPTION
### Description

Use the correct deployment targets for v1.x as shown in the following link:

https://github.com/mongodb/docs-ruby/blob/v2.0/Makefile#L9-L19
