### PR TITLE
DOCSP-32715 Add redirect for broken link in top 250 search term

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -174,3 +174,7 @@ raw: /${prefix} -> ${base}/current/
 [v2.16-*]: ${prefix}/${version}/tutorials/user-management -> ${base}/${version}/reference/user-management/
 [v2.16-*]: ${prefix}/${version}/tutorials/query-cache -> ${base}/${version}/reference/query-cache/
 [v2.16-*]: ${prefix}/${version}/quick-start -> ${base}/${version}/tutorials/quick-start/
+
+# redirects for master
+
+[master]: ${prefix}/${version}/tutorials/bson-v4/index.html -> ${base}/v2.15/tutorials/bson-v4/


### PR DESCRIPTION
Jira - https://jira.mongodb.org/browse/DOCSP-32715

Adding a redirect for a link that shows up in the top 250 search results.