### PR TITLE
DOCSP-37038: Fix broken link (staging)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mongo-ruby-driver"]
 	path = mongo-ruby-driver
-	url = https://github.com/mongodb/mongo-ruby-driver.git
-	branch = master
+	url = https://github.com/norareidy/mongo-ruby-driver.git
+	branch = DOCSP-37038-broken-link
 [submodule "bson-ruby"]
 	path = bson-ruby
 	url = https://github.com/mongodb/bson-ruby.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mongo-ruby-driver"]
 	path = mongo-ruby-driver
-	url = https://github.com/norareidy/mongo-ruby-driver.git
-	branch = DOCSP-37038-broken-link
+	url = https://github.com/mongodb/mongo-ruby-driver.git
+	branch = master
 [submodule "bson-ruby"]
 	path = bson-ruby
 	url = https://github.com/mongodb/bson-ruby.git


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-37038
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/ruby-driver/DOCSP-37038/reference/create-client/

Output from git submodule status:
```
+04602accc42dc4efb16b2171f134993e2864a3fc bson-ruby (v5.0.0)
+e459c3f75f1b1a2181b8d468751580664a3e9e04 mongo-ruby-driver (v2.19.1-43-ge459c3f75)
```

Output from git log on mongo-ruby-driver:

```
commit e459c3f75f1b1a2181b8d468751580664a3e9e04 (HEAD -> master, upstream/master, origin/master, origin/HEAD)
Author: Nora Reidy <nora.reidy@mongodb.com>
Date:   Thu Feb 22 11:34:23 2024 -0500

    DOCSP-37038: Fix broken link (#2841)
...
```

