### PR TITLE
DOCSP-37137: Fix BSON references (staging)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mongo-ruby-driver"]
 	path = mongo-ruby-driver
-	url = https://github.com/mongodb/mongo-ruby-driver.git
-	branch = 2.19-stable
+	url = https://github.com/norareidy/mongo-ruby-driver.git
+	branch = DOCSP-37137-fix-bson-references
 [submodule "bson-ruby"]
 	path = bson-ruby
 	url = https://github.com/mongodb/bson-ruby.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mongo-ruby-driver"]
 	path = mongo-ruby-driver
-	url = https://github.com/norareidy/mongo-ruby-driver.git
-	branch = DOCSP-37137-fix-bson-references
+	url = https://github.com/mongodb/mongo-ruby-driver.git
+	branch = 2.19-stable
 [submodule "bson-ruby"]
 	path = bson-ruby
 	url = https://github.com/mongodb/bson-ruby.git


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-37137
Staging - https://preview-mongodbnorareidy.gatsbyjs.io/ruby-driver/DOCSP-37137/

Output from git submodule status:
`517891b56c5e7ef1fd25e825a0c8ff4e3afd5d84 mongo-ruby-driver (v2.19.3-3-g517891b56)`

Output from git hist (on mongo-ruby-driver):
`[2024-02-28] [517891b56] | DOCSP-37137: Update BSON page references (#2844) {{Nora Reidy}}`