### PR TITLE
DOCSP-38366: Fix redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -134,8 +134,8 @@ raw: /${prefix} -> ${base}/current/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-authentication -> ${base}/${version}/reference/authentication/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-bulk-operations -> ${base}/${version}/reference/bulk-operations/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-change-streams -> ${base}/${version}/reference/change-streams/
-[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
-[v2.15-*]: ${prefix}/${version}/tutorials/client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
+[v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/in-use-encryption/client-side-encryption/
+[v2.15-*]: ${prefix}/${version}/tutorials/client-side-encryption -> ${base}/${version}/reference/in-use-encryption/client-side-encryption/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-collations -> ${base}/${version}/reference/collations/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-collection-tasks -> ${base}/${version}/reference/collection-tasks/
 [v2.15-*]: ${prefix}/${version}/tutorials/ruby-driver-create-client -> ${base}/${version}/reference/create-client/
@@ -157,8 +157,8 @@ raw: /${prefix} -> ${base}/current/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-authentication -> ${base}/${version}/reference/authentication/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-bulk-operations -> ${base}/${version}/reference/bulk-operations/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-change-streams -> ${base}/${version}/reference/change-streams/
-[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
-[v2.16-*]: ${prefix}/${version}/tutorials/client-side-encryption -> ${base}/${version}/reference/client-side-encryption/
+[v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-client-side-encryption -> ${base}/${version}/reference/in-use-encryption/client-side-encryption/
+[v2.16-*]: ${prefix}/${version}/tutorials/client-side-encryption -> ${base}/${version}/reference/in-use-encryption/client-side-encryption/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-collations -> ${base}/${version}/reference/collations/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-collection-tasks -> ${base}/${version}/reference/collection-tasks/
 [v2.16-*]: ${prefix}/${version}/tutorials/ruby-driver-create-client -> ${base}/${version}/reference/create-client/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - [DOCSP-38366](https://jira.mongodb.org/browse/DOCSP-38366)
Staging - <https://preview-mongodbmcmorisi.gatsbyjs.io/ruby-driver/DOCSP-38366-fix-redirects/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Are all the links working?

MUT output:

```
Redirect 301 /docs/ruby-driver/v2.16/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/v2.16/reference/in-use-encryption/client-side-encryption/
Redirect 301 /docs/ruby-driver/v2.17/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/v2.17/reference/in-use-encryption/client-side-encryption/
Redirect 301 /docs/ruby-driver/v2.18/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/v2.18/reference/in-use-encryption/client-side-encryption/
Redirect 301 /docs/ruby-driver/v2.19/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/v2.19/reference/in-use-encryption/client-side-encryption/
Redirect 301 /docs/ruby-driver/v2.20/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/v2.20/reference/in-use-encryption/client-side-encryption/
Redirect 301 /docs/ruby-driver/master/tutorials/ruby-driver-client-side-encryption https://www.mongodb.com/docs/ruby-driver/master/reference/in-use-encryption/client-side-encryption/
```