### PR TITLE
DOCSP-42091 Add 8.0 to compatibility table

### DIFF
--- a/source/reference/driver-compatibility.txt
+++ b/source/reference/driver-compatibility.txt
@@ -45,6 +45,7 @@ version.
    :class: compatibility-large no-padding
 
    * - Ruby Driver
+     - MongoDB 8.0
      - MongoDB 7.0
      - MongoDB 6.0
      - MongoDB 5.0
@@ -57,7 +58,22 @@ version.
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 2.21
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -
+
    * - 2.20
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -71,6 +87,7 @@ version.
      -
 
    * - 2.19
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -84,6 +101,7 @@ version.
      -
 
    * - 2.18
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -99,6 +117,7 @@ version.
    * - 2.17
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -110,6 +129,7 @@ version.
      -
 
    * - 2.16
+     -
      -
      -
      - |checkmark|
@@ -126,6 +146,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -139,6 +160,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -149,6 +171,7 @@ version.
      - |checkmark|
 
    * - 2.13
+     -
      -
      -
      -
@@ -166,6 +189,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -179,6 +203,7 @@ version.
      -
      -
      -
+     -
      - |checkmark| [#client-side-encryption]_
      - |checkmark|
      - |checkmark|
@@ -188,6 +213,7 @@ version.
      - |checkmark|
 
    * - 2.10
+     -
      -
      -
      -
@@ -206,6 +232,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -214,6 +241,7 @@ version.
      - |checkmark|
 
    * - 2.8
+     -
      -
      -
      -
@@ -232,6 +260,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -245,6 +274,7 @@ version.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -253,6 +283,7 @@ version.
      - |checkmark|
 
    * - 2.5
+     -
      -
      -
      -


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-42091
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/ruby-driver/DOCSP-42091-add-v8/reference/driver-compatibility/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
