### PR TITLE
(DOSCP-44189) [Ruby] Rename Specifications Links from RST to MD

### DIFF
--- a/source/reference/create-client.txt
+++ b/source/reference/create-client.txt
@@ -1534,7 +1534,7 @@ listed driver value:
 To use lower values, or to change the parameters in environments like JRuby
 that do not expose the required APIs, please adjust the parameters at the
 system level as described in the `MongoDB Diagnostics FAQ keepalive section
-<https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontimeoutms>`_.
+<https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.md#serverselectiontimeoutms>`_.
 
 
 Connection Pooling
@@ -1791,7 +1791,7 @@ server from the one which received the first read.
 
 The behavior of modern retryable reads is covered in detail by the
 `retryable reads specification
-<https://github.com/mongodb/specifications/blob/master/source/retryable-reads/retryable-reads.rst>`_.
+<https://github.com/mongodb/specifications/blob/master/source/retryable-reads/retryable-reads.md>`_.
 
 Note that the modern retryable reads can only be used with MongoDB 3.6 and
 higher servers. When used with MongoDB 3.4 and lower servers, Ruby driver

--- a/source/reference/crud-operations.txt
+++ b/source/reference/crud-operations.txt
@@ -490,7 +490,7 @@ timing options: **local_threshold** and **server_selection_timeout**.
 For more information on the algorithm used to select a server, please
 refer to the `Server Selection documentation, available on GitHub
 <https://github.com/mongodb/specifications/blob/master/source/server-sel
-ection/server-selection.rst>`_.
+ection/server-selection.md>`_.
 
 Read preference can be set as an option on the client or passed an
 option when a command is run on a database:
@@ -888,7 +888,7 @@ the last provided option wins in case of naming differences:
 When using transactions, write concern is only sent to the server in
 ``commit_transaction`` and ``abort_transaction`` operations
 per the `transactions specification
-<https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#writeconcern>`_.
+<https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.md#writeconcern>`_.
 Write concern may be set via the ``:write_concern`` option in a
 ``with_transaction`` or ``start_transaction`` call, or via
 ``default_transaction_options`` option on a session object.

--- a/source/reference/in-use-encryption/client-side-encryption.txt
+++ b/source/reference/in-use-encryption/client-side-encryption.txt
@@ -162,7 +162,7 @@ in order to perform automatic encryption.
   Automatic encryption is an enterprise only feature that only applies to
   operations on a collection. Automatic encryption is not supported for operations
   on a database or view, and operations that are not bypassed will result in
-  error (see `Auto Encryption Allow-List <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-allow-list>`_
+  error (see `Auto Encryption Allow-List <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#libmongocrypt-auto-encryption-allow-list>`_
   ). To bypass automatic encryption for all operations, set ``bypass_auto_encryption``
   to true in ``auto_encryption_options``.
 

--- a/source/reference/monitoring.txt
+++ b/source/reference/monitoring.txt
@@ -383,7 +383,7 @@ is being published. Note that future versions of the driver may introduce
 additional events published through this mechanism.
 
 The following events are currently implemented by the driver, following
-the `CMAP specification <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst>`_:
+the `CMAP specification <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md>`_:
 
 - PoolCreated
 - PoolCleared


### PR DESCRIPTION
Specifications files were converted from rst to md. Rename rst links to md in [4 files](https://github.com/search?q=%28repo%3Amongodb%2Fdocs-ruby%29+%28%22https%3A%2F%2Fgithub.com%2Fmongodb%2Fspecifications%22+AND+%22.rst%22%29&type=code). 

### [DOCSP-44189](https://jira.mongodb.org/browse/DOCSP-44189)

### STAGING
- [Monitoring](https://deploy-preview-75--docs-ruby.netlify.app/reference/monitoring/)
- [Client-Side Encryption](https://deploy-preview-75--docs-ruby.netlify.app/reference/in-use-encryption/client-side-encryption/)
- [Creating a Client](https://deploy-preview-75--docs-ruby.netlify.app/reference/create-client/)
- [CRUD Operations](https://deploy-preview-75--docs-ruby.netlify.app/reference/crud-operations/)