### PR TITLE
(DOCSP-44299) [Ruby] Update changelogs to remove updates for EOL'd versions v2.19 & earlier

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -4,23 +4,6 @@
 Release Notes
 *************
 
-==========
-What's New
-==========
-
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol
-
-.. facet::
-   :name: genre
-   :values: reference
- 
-.. meta::
-   :keywords: version, update, upgrade, backwards compatibility
-
 .. default-domain:: mongodb
 
 This page documents significant changes in driver releases.
@@ -33,11 +16,6 @@ comprehensive list of changes in each version of the driver and the
 <https://jira.mongodb.org/projects/RUBY?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=released>`_
 for the complete list of changes, including those internal to the driver and
 its test suite.
-
-Learn what's new in:
-
-* :ref:`Version 2.21 <release-notes-2.21>`
-* :ref:`Version 2.20 <release-notes-2.20>`
 
 .. _release-notes-2.21:
 


### PR DESCRIPTION
v2.19 has reached its end-of-life per the archival policy (linked in Epic). Release notes for this version and all earlier versions should also be removed from current versions (v2.20and later). This preserves the changelog information in the original versions (e.g. v1.18 notes are in the v1.18 changelog, but not later versions).

- JIRA - [DOCSP-44299](https://jira.mongodb.org/browse/DOCSP-44299)
- Staging - <https://deploy-preview-78--docs-ruby.netlify.app/release-notes/> 

