### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -3,7 +3,7 @@
 ====================
 
 .. meta::
-   :description: Explore the official Ruby driver for MongoDB, including installation, BSON implementation, and using Mongoid for object document mapping.
+   :description: Explore resources and tutorials to learn how to use the official Ruby driver for MongoDB.
 
 .. contents:: On this page
    :local:

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 {+driver-long+}
 ====================
 
+.. meta::
+   :description: Explore the official Ruby driver for MongoDB, including installation, BSON implementation, and using Mongoid for object document mapping.
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539