### PR TITLE
DOCSP-49145 Fix link to legacy v2.19

### DIFF
--- a/source/contribute.txt
+++ b/source/contribute.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ************************
 Contribute to the Driver
 ************************

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _getting-started:
 
 ***************

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. http://www.mongodb.org/display/DOCS/Ruby+Language+Center
 
 .. _ruby-language-center:

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ************
 Installation
 ************

--- a/source/meta/404.txt
+++ b/source/meta/404.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 :orphan:
 
 **************

--- a/source/nesting-levels.txt
+++ b/source/nesting-levels.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 This file is not part of Ruby driver documentation proper, it is an internal
 reference for the nesting levels that other files should be using.
 

--- a/source/reference/additional-resources.txt
+++ b/source/reference/additional-resources.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _ruby-external-resources:
 
 ********************

--- a/source/reference/aggregation.txt
+++ b/source/reference/aggregation.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _aggregation:
 
 ***********

--- a/source/reference/authentication.txt
+++ b/source/reference/authentication.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 **************
 Authentication
 **************

--- a/source/reference/bulk-operations.txt
+++ b/source/reference/bulk-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***********
 Bulk Writes
 ***********

--- a/source/reference/change-streams.txt
+++ b/source/reference/change-streams.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _change-streams:
 
 **************

--- a/source/reference/collations.txt
+++ b/source/reference/collations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 **********
 Collations
 **********

--- a/source/reference/collection-tasks.txt
+++ b/source/reference/collection-tasks.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***********
 Collections
 ***********

--- a/source/reference/connection-and-configuration.txt
+++ b/source/reference/connection-and-configuration.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _connection-and-configuration:
 
 **************************

--- a/source/reference/create-client.txt
+++ b/source/reference/create-client.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 *****************
 Creating a Client
 *****************

--- a/source/reference/crud-operations.txt
+++ b/source/reference/crud-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***************
 CRUD Operations
 ***************

--- a/source/reference/database-tasks.txt
+++ b/source/reference/database-tasks.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 *********
 Databases
 *********

--- a/source/reference/driver-compatibility.txt
+++ b/source/reference/driver-compatibility.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _compatibility:
 
 ********************

--- a/source/reference/geospatial-search.txt
+++ b/source/reference/geospatial-search.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 *****************
 Geospatial Search
 *****************

--- a/source/reference/gridfs.txt
+++ b/source/reference/gridfs.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _gridfs:
 
 ******

--- a/source/reference/in-use-encryption.txt
+++ b/source/reference/in-use-encryption.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _in-use-encryption:
 
 *****************

--- a/source/reference/in-use-encryption/client-side-encryption.txt
+++ b/source/reference/in-use-encryption/client-side-encryption.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _client-side-encryption:
 
 **********************

--- a/source/reference/in-use-encryption/queryable-encryption.txt
+++ b/source/reference/in-use-encryption/queryable-encryption.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _queryable-encryption:
 
 **********************

--- a/source/reference/indexing.txt
+++ b/source/reference/indexing.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ********
 Indexing
 ********

--- a/source/reference/map-reduce.txt
+++ b/source/reference/map-reduce.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 **********
 Map-Reduce
 **********

--- a/source/reference/monitoring.txt
+++ b/source/reference/monitoring.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 **********
 Monitoring
 **********

--- a/source/reference/projection.txt
+++ b/source/reference/projection.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 **********
 Projection
 **********

--- a/source/reference/query-cache.txt
+++ b/source/reference/query-cache.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***********
 Query Cache
 ***********

--- a/source/reference/schema-operations.txt
+++ b/source/reference/schema-operations.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _schema-operations:
 
 *****************

--- a/source/reference/search-indexes.txt
+++ b/source/reference/search-indexes.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ********************
 Atlas Search Indexes
 ********************

--- a/source/reference/sessions.txt
+++ b/source/reference/sessions.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _sessions:
 
 ********

--- a/source/reference/text-search.txt
+++ b/source/reference/text-search.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***********
 Text Search
 ***********

--- a/source/reference/transactions.txt
+++ b/source/reference/transactions.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ************
 Transactions
 ************

--- a/source/reference/user-management.txt
+++ b/source/reference/user-management.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _user-management:
 
 ***************

--- a/source/reference/working-with-data.txt
+++ b/source/reference/working-with-data.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _working-with-data:
 
 *****************

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _release-notes:
 
 *************

--- a/source/support.txt
+++ b/source/support.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 *******
 Support
 *******

--- a/source/tutorials.txt
+++ b/source/tutorials.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. _tutorials:
 
 *********

--- a/source/tutorials/bson.txt
+++ b/source/tutorials/bson.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 .. https://www.mongodb.com/docs/ecosystem/tutorial/ruby-bson-tutorial/
 
 .. _ruby-bson-tutorial:

--- a/source/tutorials/common-errors.txt
+++ b/source/tutorials/common-errors.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 *************
 Common Errors
 *************

--- a/source/tutorials/quick-start.txt
+++ b/source/tutorials/quick-start.txt
@@ -1,3 +1,6 @@
+.. meta::
+   :robots: noindex, nosnippet 
+
 ***********
 Quick Start
 ***********


### PR DESCRIPTION
# Pull Request Info

Ticket links to a legacy version (v2.19) of the docs, so hopefully this will make this version of the site unavailable to crawlers. 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49145>

### Staging Links

<!-- start insert-links --><!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?